### PR TITLE
feat: 사용자 정보 수정 API 구현

### DIFF
--- a/src/auth/login-strategy.ts
+++ b/src/auth/login-strategy.ts
@@ -1,9 +1,9 @@
 import passport from 'passport';
 import { Strategy as LocalStrategy } from 'passport-local';
 import bcrypt from 'bcrypt';
-import Users from '../databases/models/users';
 import ErrorMessage from '../error/error-message';
-import Permissions from '../databases/models/permissions';
+import { getUserById } from '../services/auth-service';
+import ServiceException from '../exceptions';
 
 export default (): void => {
   passport.use('login', new LocalStrategy({
@@ -11,26 +11,17 @@ export default (): void => {
     passwordField: 'password'
   }, async (id, password, done) => {
     try {
-      const user = await Users.findOne({
-        where: {
-          id
-        },
-        include: [
-          {
-            model: Permissions,
-            attributes: ['isAdmin', 'isTeacher', 'isSchoolUnion'],
-            as: 'permission'
-          }
-        ] as never
-      });
-
-      if (!user) return done(null, false, { message: ErrorMessage.USER_NOT_FOUND });
+      const user = await getUserById(id);
 
       const compared = bcrypt.compareSync(password, user.password);
       if (!compared) return done(null, false, { message: ErrorMessage.USER_NOT_FOUND });
 
       return done(null, user);
     } catch (e) {
+      if (e instanceof ServiceException && e.message === ErrorMessage.USER_NOT_FOUND) {
+        return done(null, false, { message: ErrorMessage.USER_NOT_FOUND });
+      }
+
       return done(e);
     }
   }));

--- a/src/auth/login-strategy.ts
+++ b/src/auth/login-strategy.ts
@@ -2,8 +2,8 @@ import passport from 'passport';
 import { Strategy as LocalStrategy } from 'passport-local';
 import bcrypt from 'bcrypt';
 import ErrorMessage from '../error/error-message';
-import { getUserById } from '../services/auth-service';
 import ServiceException from '../exceptions';
+import { getUser } from '../services/auth-service';
 
 export default (): void => {
   passport.use('login', new LocalStrategy({
@@ -11,7 +11,7 @@ export default (): void => {
     passwordField: 'password'
   }, async (id, password, done) => {
     try {
-      const user = await getUserById(id);
+      const user = await getUser(id, 'id', true);
 
       const compared = bcrypt.compareSync(password, user.password);
       if (!compared) return done(null, false, { message: ErrorMessage.USER_NOT_FOUND });

--- a/src/error/error-message.ts
+++ b/src/error/error-message.ts
@@ -4,6 +4,7 @@ enum ErrorMessage {
 
   USER_NOT_FOUND = '존재하지 않는 사용자입니다.',
   USER_ALREADY_EXISTS = '이미 존재하는 아이디입니다.',
+  USER_PASSWORD_NOT_MATCH = '현재 비밀번호가 일치하지 않습니다.',
 
   UMBRELLA_NOT_FOUND = '존재하지 않는 우산입니다.',
   UMBRELLA_ALREADY_EXISTS = '이미 존재하는 우산입니다.',

--- a/src/routers/auth-router.ts
+++ b/src/routers/auth-router.ts
@@ -184,8 +184,6 @@ router.get('/me', requireAuthenticated(), async (req: express.Request, res: expr
   const result: any = req.user;
   if (!result) return;
 
-  result.password = '';
-
   res.status(200).json({
     success: true,
     data: result
@@ -210,8 +208,6 @@ router.get('/user/:uuid', requireAuthenticated(['admin', 'teacher', 'schoolunion
   const { uuid } = req.params;
 
   const data = await getUser(uuid);
-
-  data.password = '';
 
   res.status(200).json({
     success: true,
@@ -283,8 +279,6 @@ router.get('/user', requireAuthenticated(['admin', 'teacher']), async (req: expr
  */
 router.delete('/logout', requireAuthenticated(), (req: express.Request, res: express.Response) => {
   const result: any = req.user;
-
-  result.password = '';
 
   logger.info(`${result.uuid} ${result.id} 님이 로그아웃을 하였습니다.`);
   req.logout();

--- a/src/routers/auth-router.ts
+++ b/src/routers/auth-router.ts
@@ -5,6 +5,7 @@ import { makeError } from '../error/error-system';
 import ErrorMessage from '../error/error-message';
 import { logger } from '../index';
 import {
+  editUser,
   getMyPermission,
   getUser,
   getUsers,
@@ -17,6 +18,7 @@ import { checkValidation } from '../middlewares/validator';
 import { useActivationCode } from '../services/activation-code-service';
 import ServiceException from '../exceptions';
 import Users from '../databases/models/users';
+import { UserWithPermissions } from '../types';
 
 const router = express.Router();
 
@@ -288,5 +290,61 @@ router.delete('/logout', requireAuthenticated(), (req: express.Request, res: exp
     data: result
   });
 });
+
+const editUserValidator = [
+  body('studentGrade').isNumeric(),
+  body('studentClass').isNumeric(),
+  body('studentNumber').isNumeric(),
+  body('currentPassword').isString(),
+  body('newPassword').isString()
+];
+/**
+ * @api {put} /auth/me 유저 정보 수정
+ * @apiName EditUser
+ * @apiGroup Auth
+ *
+ * @apiSuccess {Boolean} success 성공 여부
+ * @apiSuccess {Object} data 유저 데이터
+ *
+ * @apiError (Error 401) USER_PASSWORD_NOT_MATCH 현재 비밀번호가 일치하지 않습니다.
+ * @apiError (Error 500) SERVER_ERROR 오류가 발생하였습니다. 잠시후 다시 시도해주세요.
+ */
+router.put('/me',
+  requireAuthenticated(),
+  editUserValidator,
+  checkValidation,
+  async (req: express.Request, res: express.Response) => {
+    const { studentGrade, studentClass, studentNumber, currentPassword, newPassword } = req.body;
+    const loginedUser = req.user as UserWithPermissions;
+
+    try {
+      const data = await editUser(loginedUser.uuid, {
+        studentGrade,
+        studentClass,
+        studentNumber,
+        currentPassword,
+        newPassword
+      });
+
+      res.status(200).json({
+        success: true,
+        data
+      });
+
+      logger.info(`${loginedUser.uuid} 사용자 정보를 수정했습니다.`);
+    } catch (e) {
+      if (e instanceof ServiceException) {
+        if (e.message === ErrorMessage.USER_PASSWORD_NOT_MATCH) {
+          logger.warn(`${loginedUser.uuid} 사용자 정보 수정을 위한 비밀번호가 틀렸습니다.`);
+        }
+        res.status(e.httpStatus).json(makeError(e.message));
+        return;
+      }
+
+      res.status(500).json(makeError(ErrorMessage.SERVER_ERROR));
+      logger.error('사용자 정보를 수정하는 중 오류가 발생하였습니다.');
+      logger.error(e);
+    }
+  });
 
 export default router;

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -2,11 +2,11 @@ import Users from '../databases/models/users';
 import ServiceException from '../exceptions';
 import ErrorMessage from '../error/error-message';
 import Permissions from '../databases/models/permissions';
-import { PermissionType } from '../types';
+import { PermissionType, UserWithPermissions } from '../types';
 import { pagination, search } from '../utils/router-util';
 import { PaginationResult } from '../types/pagination-result';
 
-export const getUser = async (value: string, type?: 'id' | 'uuid', showPassword?: boolean): Promise<Users & { permission: Permissions }> => {
+export const getUser = async (value: string, type?: 'id' | 'uuid', showPassword?: boolean): Promise<UserWithPermissions> => {
   const key = type ?? 'uuid';
   const passwordOption = showPassword ? {} : {
     attributes: {
@@ -30,7 +30,7 @@ export const getUser = async (value: string, type?: 'id' | 'uuid', showPassword?
 
   if (!result) throw new ServiceException(ErrorMessage.USER_NOT_FOUND, 404);
 
-  return result as Users & { permission: Permissions };
+  return result as UserWithPermissions;
 };
 
 export const getUserWithInfo = async (
@@ -40,7 +40,7 @@ export const getUserWithInfo = async (
   clazz: number,
   number: number,
   showPassword?: boolean
-): Promise<Users & { permission: Permissions }> => {
+): Promise<UserWithPermissions> => {
   const passwordOption = showPassword ? {} : {
     attributes: {
       exclude: ['password']
@@ -67,7 +67,7 @@ export const getUserWithInfo = async (
 
   if (!user) throw new ServiceException(ErrorMessage.USER_NOT_FOUND, 404);
 
-  return user as Users & { permission: Permissions };
+  return user as UserWithPermissions;
 };
 
 interface UserInfoParams {
@@ -78,6 +78,7 @@ interface UserInfoParams {
   readonly studentClass: number;
   readonly studentNumber: number;
 }
+
 export const registerUser = async (userInfo: UserInfoParams): Promise<Users> => {
   const { id, name, department, studentGrade, studentClass, studentNumber } = userInfo;
 
@@ -155,7 +156,7 @@ export const getUsers = async (
   limit?: number,
   searchQuery?: string,
   filters?: GetUsersFilters
-): Promise<PaginationResult<Users[]>> => {
+): Promise<PaginationResult<UserWithPermissions[]>> => {
   const searchOption = search<Users>(searchQuery, 'name');
   const option = pagination(page, limit);
 
@@ -204,6 +205,6 @@ export const getUsers = async (
 
   return {
     count,
-    data
+    data: data as UserWithPermissions[]
   };
 };

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -15,36 +15,19 @@ interface UserInfoParams {
   readonly studentNumber: number;
 }
 
-export const getUserById = async (id: string): Promise<Users> => {
-  const result = await Users.findOne({
-    where: {
-      id
-    },
+export const getUser = async (value: string, type?: 'id' | 'uuid', showPassword?: boolean): Promise<Users> => {
+  const key = type ?? 'uuid';
+  const passwordOption = showPassword ? {} : {
     attributes: {
       exclude: ['password']
-    },
-    include: [
-      {
-        model: Permissions,
-        attributes: ['isAdmin', 'isTeacher', 'isSchoolUnion'],
-        as: 'permission'
-      }
-    ] as never
-  });
+    }
+  };
 
-  if (!result) throw new ServiceException(ErrorMessage.USER_NOT_FOUND, 404);
-
-  return result;
-};
-
-export const getUser = async (uuid: string): Promise<Users> => {
   const result = await Users.findOne({
     where: {
-      uuid
+      [key]: value
     },
-    attributes: {
-      exclude: ['password']
-    },
+    ...passwordOption,
     include: [
       {
         model: Permissions,

--- a/src/services/contest-service.ts
+++ b/src/services/contest-service.ts
@@ -5,7 +5,6 @@ import ServiceException from '../exceptions';
 import ErrorMessage from '../error/error-message';
 import { PaginationResult } from '../types/pagination-result';
 import { pagination, search } from '../utils/router-util';
-import { logger } from '../index';
 
 export const addContestMember = async (uuid: string, role: ContestRole): Promise<Contests> => {
   const user = await getUser(uuid);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,6 @@
+import Users from '../databases/models/users';
+import Permissions from '../databases/models/permissions';
+
 export enum UmbrellaStatus {
   GOOD = 'good',
   WORSE = 'worse'
@@ -35,3 +38,5 @@ export enum ContestRole {
   DEVELOP,
   DESIGN
 }
+
+export type UserWithPermissions = Users & { permission: Permissions };


### PR DESCRIPTION
## 🚨 어떤 문제 상황이였나요?
- password 정보 삭제 시 처음 가져올 때 제외하지 않고 중간에 삭제하였습니다.
- 일부 함수 반환 타입에 Permissions 모델 정보가 포함 되어있지 않습니다.

## 😎 어떤 기능이 추가되거나 변경되었나요?
- `exclude` 옵션 및 `showPassword` 파라미터를 통해 password 정보를 삭제할 지 정할 수 있습니다.
- `UserWithPermissions` 타입을 통해 유저 정보와 함께 펄미션 정보를 나타낼 수 있습니다.
- `getUser()` 옵션을 통해 uuid 또는 id로 가져올지 선택할 수 있습니다.
- 사용자 정보 수정 API를 구현했습니다.

## ❗ 주의하거나 참고할 점이 있나요?
- `getUser()` 옵션 참고
- `UserWithPermissions` 타입 추가

## 📷 스크린샷


