### PR TITLE
refactor: 로그인 및 회원가입 로직 리팩토링

### DIFF
--- a/src/auth/login-strategy.ts
+++ b/src/auth/login-strategy.ts
@@ -4,6 +4,7 @@ import bcrypt from 'bcrypt';
 import ErrorMessage from '../error/error-message';
 import ServiceException from '../exceptions';
 import { getUser } from '../services/auth-service';
+import { logger } from '../index';
 
 export default (): void => {
   passport.use('login', new LocalStrategy({
@@ -14,7 +15,10 @@ export default (): void => {
       const user = await getUser(id, 'id', true);
 
       const compared = bcrypt.compareSync(password, user.password);
-      if (!compared) return done(null, false, { message: ErrorMessage.USER_NOT_FOUND });
+      if (!compared) {
+        logger.warn(`${user.uuid} ${user.id} 사용자 비밀번호가 틀렸습니다.`);
+        return done(null, false, { message: ErrorMessage.USER_NOT_FOUND });
+      }
 
       return done(null, user);
     } catch (e) {

--- a/src/auth/login-strategy.ts
+++ b/src/auth/login-strategy.ts
@@ -3,27 +3,53 @@ import { Strategy as LocalStrategy } from 'passport-local';
 import bcrypt from 'bcrypt';
 import ErrorMessage from '../error/error-message';
 import ServiceException from '../exceptions';
-import { getUser } from '../services/auth-service';
+import { getMyPermission, getUser } from '../services/auth-service';
 import { logger } from '../index';
+
+const userNotFoundErrorMessage = JSON.stringify({
+  message: ErrorMessage.USER_NOT_FOUND,
+  status: 404
+});
 
 export default (): void => {
   passport.use('login', new LocalStrategy({
     usernameField: 'id',
-    passwordField: 'password'
-  }, async (id, password, done) => {
+    passwordField: 'password',
+    passReqToCallback: true
+  }, async (req, id, password, done) => {
+    const { admin } = req.query;
+
+    const adminQuery = admin || 'false';
+    const isAdminLogin = adminQuery.toString().toLowerCase() === 'true';
+
     try {
       const user = await getUser(id, 'id', true);
 
       const compared = bcrypt.compareSync(password, user.password);
       if (!compared) {
         logger.warn(`${user.uuid} ${user.id} 사용자 비밀번호가 틀렸습니다.`);
-        return done(null, false, { message: ErrorMessage.USER_NOT_FOUND });
+        return done(null, false, { message: userNotFoundErrorMessage });
+      }
+
+      const myPermission = await getMyPermission(user.uuid);
+      const isHavePermission = myPermission.some((v) => ['admin', 'teacher', 'schoolunion'].includes(v));
+      if (isAdminLogin && !isHavePermission) {
+        const errorMessage = JSON.stringify({
+          message: ErrorMessage.NO_PERMISSION,
+          status: 401
+        });
+        logger.warn(`${user.uuid} ${user.id} 사용자가 관자 페이지 로그인을 시도하였습니다.`);
+        return done(null, false, { message: errorMessage });
       }
 
       return done(null, user);
     } catch (e) {
-      if (e instanceof ServiceException && e.message === ErrorMessage.USER_NOT_FOUND) {
-        return done(null, false, { message: ErrorMessage.USER_NOT_FOUND });
+      if (e instanceof ServiceException) {
+        const errorMessage = JSON.stringify({
+          message: e.message,
+          status: e.httpStatus
+        });
+        return done(null, false, { message: errorMessage });
       }
 
       return done(e);

--- a/src/auth/register-strategy.ts
+++ b/src/auth/register-strategy.ts
@@ -1,36 +1,48 @@
 import passport from 'passport';
 import { Strategy as LocalStrategy } from 'passport-local';
-import bcrypt from 'bcrypt';
-import { v4 as uuidv4 } from 'uuid';
-import Users from '../databases/models/users';
-import ErrorMessage from '../error/error-message';
-import config from '../config';
+import { getUser, initUserPermission, registerUser } from '../services/auth-service';
+import ServiceException from '../exceptions';
 
 export default (): void => {
   passport.use('register', new LocalStrategy({
     usernameField: 'id',
-    passwordField: 'password'
-  }, async (id, password, done) => {
+    passwordField: 'password',
+    passReqToCallback: true
+  }, async (req, id, password, done) => {
     try {
-      const currentUser = await Users.findOne({
-        where: {
-          id
-        }
-      });
+      const {
+        name,
+        department,
+        studentGrade,
+        studentClass,
+        studentNumber,
+        code
+      } = req.body;
 
-      if (currentUser) {
-        return done(null, false, { message: ErrorMessage.USER_ALREADY_EXISTS });
-      }
-
-      const hashed = await bcrypt.hash(password, config.saltRound);
-      const user = await Users.create({
-        uuid: uuidv4(),
+      const result = await registerUser({
         id,
-        password: hashed
+        password,
+        name,
+        department,
+        studentGrade,
+        studentClass,
+        studentNumber,
+        code
       });
 
-      return done(null, user);
+      await initUserPermission(result.uuid);
+
+      const userDataWithPermission = await getUser(result.uuid);
+
+      return done(null, userDataWithPermission);
     } catch (e) {
+      if (e instanceof ServiceException) {
+        const errorMessage = JSON.stringify({
+          message: e.message,
+          status: e.httpStatus
+        });
+        return done(null, false, { message: errorMessage });
+      }
       return done(e);
     }
   }));

--- a/src/auth/register-strategy.ts
+++ b/src/auth/register-strategy.ts
@@ -12,13 +12,13 @@ export default (): void => {
     passwordField: 'password'
   }, async (id, password, done) => {
     try {
-      const prevUser = await Users.findOne({
+      const currentUser = await Users.findOne({
         where: {
           id
         }
       });
 
-      if (prevUser) {
+      if (currentUser) {
         return done(null, false, { message: ErrorMessage.USER_ALREADY_EXISTS });
       }
 

--- a/src/routers/auth-router.ts
+++ b/src/routers/auth-router.ts
@@ -148,31 +148,16 @@ const loginValidator = [
   body('password')
 ];
 router.post('/login', loginValidator, checkValidation, (req: express.Request, res: express.Response, next: express.NextFunction) => {
-  const { admin } = req.query;
-
-  const adminQuery = admin || 'false';
-  const isAdminLogin = adminQuery.toString().toLowerCase() === 'true';
-
   passport.authenticate('login', async (error, user, info) => {
     if (error) {
-      logger.error('로그인 완료 중 오류가 발생하였습니다.');
-      logger.error(error);
+      logger.error('로그인 완료 중 오류가 발생하였습니다.', error);
       res.status(500).json(makeError(ErrorMessage.SERVER_ERROR));
       return;
     }
 
     if (info) {
-      if (info.message === ErrorMessage.USER_NOT_FOUND) {
-        res.status(404).json(makeError(ErrorMessage.USER_NOT_FOUND));
-      }
-      return;
-    }
-
-    const myPermission = await getMyPermission(user.uuid);
-    const isHavePermission = myPermission.some((v) => ['admin', 'teacher', 'schoolunion'].includes(v));
-    if (isAdminLogin && !isHavePermission) {
-      logger.warn(`${user.uuid} ${user.id} 사용자가 관리자 페이지 로그인을 시도하였습니다.`);
-      res.status(401).json(makeError(ErrorMessage.NO_PERMISSION));
+      const errorMessage = JSON.parse(info.message);
+      res.status(errorMessage.status).json(makeError(errorMessage.message));
       return;
     }
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -97,7 +97,12 @@ export const registerUser = async (userInfo: UserInfoParams): Promise<Users> => 
     code
   } = userInfo;
 
-  const currentUser = await getUser(id, 'id');
+  const currentUser = await Users.findOne({
+    where: {
+      id
+    }
+  });
+
   if (currentUser) throw new ServiceException(ErrorMessage.USER_ALREADY_EXISTS, 409);
 
   await useActivationCode(code);

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcrypt';
 import { Op } from 'sequelize';
+import { v4 as uuidv4 } from 'uuid';
 import Users from '../databases/models/users';
 import ServiceException from '../exceptions';
 import ErrorMessage from '../error/error-message';
@@ -8,6 +9,7 @@ import { PermissionType, UserWithPermissions } from '../types';
 import { filter, FilterParam, pagination } from '../utils/router-util';
 import { PaginationResult } from '../types/pagination-result';
 import config from '../config';
+import { useActivationCode } from './activation-code-service';
 
 export const getUser = async (value: string, type?: 'id' | 'uuid', showPassword?: boolean): Promise<UserWithPermissions> => {
   const key = type ?? 'uuid';
@@ -75,31 +77,44 @@ export const getUserWithInfo = async (
 
 interface UserInfoParams {
   readonly id: string;
+  readonly password: string;
   readonly name: string;
   readonly department: number;
   readonly studentGrade: number;
   readonly studentClass: number;
   readonly studentNumber: number;
+  readonly code: string;
 }
 export const registerUser = async (userInfo: UserInfoParams): Promise<Users> => {
-  const { id, name, department, studentGrade, studentClass, studentNumber } = userInfo;
+  const {
+    id,
+    password,
+    name,
+    department,
+    studentGrade,
+    studentClass,
+    studentNumber,
+    code
+  } = userInfo;
 
-  const user = await getUser(id, 'id');
-  if (!user) throw new ServiceException(ErrorMessage.USER_NOT_FOUND, 404);
+  const currentUser = await getUser(id, 'id');
+  if (currentUser) throw new ServiceException(ErrorMessage.USER_ALREADY_EXISTS, 409);
 
-  await user.update({
+  await useActivationCode(code);
+
+  const hashed = await bcrypt.hash(password, config.saltRound);
+  const result = await Users.create({
+    uuid: uuidv4(),
+    id,
+    password: hashed,
     name,
     department,
     studentGrade,
     studentClass,
     studentNumber
-  }, {
-    where: {
-      id
-    }
   });
 
-  return user;
+  return result;
 };
 
 export const initUserPermission = async (uuid: string): Promise<Permissions> => {

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -84,15 +84,7 @@ interface UserInfoParams {
 export const registerUser = async (userInfo: UserInfoParams): Promise<Users> => {
   const { id, name, department, studentGrade, studentClass, studentNumber } = userInfo;
 
-  const user = await Users.findOne({
-    where: {
-      id
-    },
-    attributes: {
-      exclude: ['password']
-    }
-  });
-
+  const user = await getUser(id, 'id');
   if (!user) throw new ServiceException(ErrorMessage.USER_NOT_FOUND, 404);
 
   await user.update({


### PR DESCRIPTION
## 😎 어떤 기능이 추가되거나 변경되었나요?
- 기존 `auth-router.ts` 에 모여있던 Login, Register 관련 로직을 분리했습니다.
  - 로그인, 회원가입에 관여하는 로직은 각각 `login-strategy.ts` `register-strategy.ts` 으로 이동했습니다.
- 사용자 로그인 시 비밀번호가 틀리면 로그를 출력하도록 바꿨습니다.

## ❗ 주의하거나 참고할 점이 있나요?
- Passport message 타입이 string이라 여러 정보를 넘길 수가 없습니다. `JSON.stringify()` 를 사용하여 문자열로 바꾼 후 라우터에서 `JSON.parse()` 로 다시 사용하는 방식을 이용했습니다.
